### PR TITLE
maze centreren + andere texturen

### DIFF
--- a/draw.cpp
+++ b/draw.cpp
@@ -8,7 +8,7 @@ void Window::resize(int width, int height){
 	const char* temp = ss.str().c_str();
 	std::cout << temp;
 	*/
-	this->width = 50;
+	this->width = 25;
 	this->height = 30;
 
 	// Code taken and modified from: https://stackoverflow.com/questions/7552644/resize-cmd-window
@@ -22,12 +22,13 @@ void Window::update(int width, std::vector<int> &losmatrix, std::vector<int> &co
 	std::string temp;
 	
 	// Margin top
-	int top_margin = (this->width/2-width)/2;;
+	int top_margin = (this->width - width)/2;
+	// Appends an integer (top_margin) times the character given.
 	temp.append<int>(top_margin, '\n');
 	ss << temp;
 	
-	// Calculate size of margin, result is rounded down because it's an integer
-	int size_margin = (this->width/2 - width);
+	// Calculate size of margin
+	int size_margin = this->width - width;
 	temp.clear();
 	temp.append<int>(size_margin, ' ');
 	// Show the line of sight matrix of the player
@@ -45,6 +46,7 @@ void Window::update(int width, std::vector<int> &losmatrix, std::vector<int> &co
 		else ss << (char) 32 << losmatrix[i];	// This copies the numbers that need to be collected.
 	}
 	
+	// Fill below los_grid untill text
 	temp.clear();
 	temp.append<int>(top_margin, '\n');
 	ss << temp;
@@ -59,7 +61,7 @@ void Window::update(int width, std::vector<int> &losmatrix, std::vector<int> &co
 	}
 	
 	// Fill screen up with newlines
-	int bot_margin = this->height-this->width/2  - 2;
+	int bot_margin = this->height - this->width  - 2;
 	temp.clear();
 	temp.append<int>(bot_margin, '\n');
 	ss << temp;

--- a/draw.cpp
+++ b/draw.cpp
@@ -19,23 +19,38 @@ void Window::resize(int width, int height){
 
 void Window::update(int width, std::vector<int> &losmatrix, std::vector<int> &collected_numbers){
 	std::stringstream ss;
+	std::string temp;
 	
+	// Margin top
+	int top_margin = (this->width/2-width)/2;;
+	temp.append<int>(top_margin, '\n');
+	ss << temp;
+	
+	// Calculate size of margin, result is rounded down because it's an integer
+	int size_margin = (this->width/2 - width);
+	temp.clear();
+	temp.append<int>(size_margin, ' ');
 	// Show the line of sight matrix of the player
 	for (int i=0; i<losmatrix.size(); i++){
-		if (i%width==0 && i!=0)
-			ss << '\n';
+		if (i%width==0)
+			ss << '\n' << temp;
 		if (i == width*width/2)					// This is the location of the player.
-			ss << (char) 120 << (char) 120;	
+			ss << (char) 218 << (char) 191;	
+		else if (losmatrix[i]==-2)
+			ss << (char) 177 << (char) 177;
 		else if (losmatrix[i]==-1)
-			ss << (char) 178 << (char) 178;
+			ss << (char) 219 << (char) 219;
 		else if (losmatrix[i]==0)
 			ss << (char) 32 << (char) 32;
 		else ss << (char) 32 << losmatrix[i];	// This copies the numbers that need to be collected.
 	}
 	
+	temp.clear();
+	temp.append<int>(top_margin, '\n');
+	ss << temp;
+	
 	// Show collected numbers on the screen
-
-	ss << "\n\n Numbers collected: \n ";
+	ss << "\n Numbers collected: \n ";
 	std::vector<int>::iterator it;
 	it = collected_numbers.begin();
 	while (it !=collected_numbers.end()){	// Loop through collected_numbers
@@ -44,7 +59,10 @@ void Window::update(int width, std::vector<int> &losmatrix, std::vector<int> &co
 	}
 	
 	// Fill screen up with newlines
-	for (int i=0; i<= (this->height-width-4); i++)
-		ss << '\n';
+	int bot_margin = this->height-this->width/2  - 2;
+	temp.clear();
+	temp.append<int>(bot_margin, '\n');
+	ss << temp;
+	
 	std::cout << ss.str();
 }

--- a/draw.h
+++ b/draw.h
@@ -7,6 +7,7 @@
 #include <sstream>
 
 class Window {
+	// This is the width in characters, 1 width = 2 characters, height is just height
 	int width, height;
 public:
 	void resize(int width, int height);	// resizes window in character dimensions

--- a/player.cpp
+++ b/player.cpp
@@ -17,7 +17,7 @@ void Player::update_los_grid(Level* levelobject){
 			int x = this->x-this->los+j;	// 'x_player - los' to get to the left edge of the los_grid, '+j' to loop from left to right.
 			int y = this->y-this->los+i;	// Same here but then for y coordinate.
 			if(x<0 || y<0 || x>=levelobject->width || y>=levelobject->height)	// This is outside of the maze (occurs at the edges of the maze).
-				this->los_grid[size*i+j] = 0;
+				this->los_grid[size*i+j] = -2;
 			else
 				this->los_grid[size*i+j] = levelobject->maze[y*levelobject->width+x];	// else copy the value of the maze at that coordinate.
 		}


### PR DESCRIPTION
maze wordt nu in het midden van scherm weergegeven en alles buiten de maze is nu grijs. Ook is de textuur van de muur veranderd naar een solid block en de player sprite is geupdate.