### PR TITLE
Load levelfiles

### DIFF
--- a/draw.cpp
+++ b/draw.cpp
@@ -24,8 +24,7 @@ void Window::get_list_levelfiles(){
 	// Check if directory exists
 	char cCurrentPath[FILENAME_MAX];
 	if (!GetCurrentDir(cCurrentPath, sizeof(cCurrentPath))){
-		std::cout << "Can't get current directory" << std::endl;
-		return;
+		throw(std::invalid_argument("Cannot get current directory"));
 	}
 	
 	// Loop over files with name "lvl*.txt"
@@ -34,8 +33,7 @@ void Window::get_list_levelfiles(){
 	WIN32_FIND_DATAA ffd;
 	HANDLE hFind = FindFirstFileA(temp.c_str(), &ffd);
 	if(hFind== INVALID_HANDLE_VALUE){
-		std::cout << "No level files found, add some levels with name 'lvl#.txt'." << std::endl;;
-		return;
+		throw(std::invalid_argument("No level files found, add some levels with filename 'lvl#.txt'."));
 	}
 	do {
 	    this->menu_items.push_back(ffd.cFileName);

--- a/draw.cpp
+++ b/draw.cpp
@@ -11,15 +11,35 @@ Window::Window(){
 	this->width = 25;
 	this->height = 30;
 	this->menu_selected_item = 0;
-	this->menu_items.push_back("Level 1");
-	this->menu_items.push_back("Level 2");
-	this->menu_items.push_back("Level 3");
+	this->get_list_levelfiles();
 	this->menu_items.push_back("Quit");
 
 	// Code taken and modified from: https://stackoverflow.com/questions/7552644/resize-cmd-window
 	system("mode 50,30");   //Set mode to ensure window does not exceed buffer size
   	SMALL_RECT WinRect = {0, 0, 50, 30};   //New dimensions for window in 8x12 pixel chars
   	SetConsoleWindowInfo(GetStdHandle(STD_OUTPUT_HANDLE), true, &WinRect);   //Set new size for window
+}
+
+void Window::get_list_levelfiles(){
+	// Check if directory exists
+	char cCurrentPath[FILENAME_MAX];
+	if (!GetCurrentDir(cCurrentPath, sizeof(cCurrentPath))){
+		std::cout << "Can't get current directory" << std::endl;
+		return;
+	}
+	
+	// Loop over files with name "lvl*.txt"
+	std::string temp (cCurrentPath);
+	temp += "\\lvl*.txt";
+	WIN32_FIND_DATAA ffd;
+	HANDLE hFind = FindFirstFileA(temp.c_str(), &ffd);
+	if(hFind== INVALID_HANDLE_VALUE){
+		std::cout << "No level files found, add some levels with name 'lvl#.txt'." << std::endl;;
+		return;
+	}
+	do {
+	    this->menu_items.push_back(ffd.cFileName);
+	} while (FindNextFileA(hFind, &ffd) != 0);
 }
 
 void Window::menu_down(){
@@ -53,7 +73,11 @@ void Window::draw_title(){
 			ss << "\t-->";
 		else
 			ss << "\t   ";
-		ss << *it << "\n";
+		
+		if (*it=="Quit")
+			ss << *it << "\n";
+		else
+			ss << "Level " << std::string(*it).substr(3,1) << "\n";
 		it++;
 	}
 	// Fill screen with newline characters

--- a/draw.h
+++ b/draw.h
@@ -5,6 +5,10 @@
 #include <iostream>
 #include <vector>
 #include <sstream>
+#include <stdio.h>
+#include <direct.h>
+#include <string>
+#define GetCurrentDir _getcwd
 
 class Window {
 	// This is the width in characters, 1 width = 2 characters, height is just height
@@ -13,6 +17,7 @@ class Window {
 	int menu_selected_item;
 public:
 	Window();	// resizes window
+	void get_list_levelfiles();
 	void menu_down();
 	void menu_up();
 	std::string menu_get_name_selected();

--- a/draw.h
+++ b/draw.h
@@ -9,6 +9,7 @@
 #include <direct.h>
 #include <string>
 #define GetCurrentDir _getcwd
+#include <stdexcept>
 
 class Window {
 	// This is the width in characters, 1 width = 2 characters, height is just height

--- a/main.cpp
+++ b/main.cpp
@@ -23,14 +23,11 @@ int main() {
 		}else if(GetAsyncKeyState(VK_UP)){
 			canvas->menu_up();
 		}else if(GetAsyncKeyState(VK_RETURN)){
-			std::string temp = canvas->menu_get_name_selected();
-			if(temp == "Quit"){
+			// Get filename of selected level
+			std::string filename = canvas->menu_get_name_selected();
+			if(filename == "Quit"){
 				running = false;
 			}else {
-				// Create filename string of selected level
-				std::string filename = "lvl";
-				filename += temp[6];
-				filename += ".txt";
 				// level(filename, ratio nr generation)
 				Level* lvl = new Level(filename , 5);
 				// player(begin x, begin y, LOS, pointer to level)

--- a/main.cpp
+++ b/main.cpp
@@ -5,10 +5,12 @@
 #include <iostream>
 #include <windows.h>
 #include <vector>
+#include <stdexcept>
 
 void loop_maze(Window* canvas, Level* lvl, Player* player, int frameduration);
 
 int main() {
+	try{
 	int frameduration = 80;
 	Window* canvas = new Window;
 	
@@ -42,8 +44,11 @@ int main() {
 		canvas->draw_title();
 		
 		while(GetTickCount()-time <frameduration ){}
+	} 
+	}catch (std::exception& e){
+		std::cerr << "Error: " << e.what() << std::endl;
+		return EXIT_FAILURE;
 	}
-	
 	return 0;
 }
 

--- a/read.cpp
+++ b/read.cpp
@@ -27,8 +27,9 @@ Level::Level(std::string filename, int ratio){
 		this->height=height;
 		// Define the size of the maze vector.
 		this->maze.resize(width*height);
+	} else {
+		throw(std::invalid_argument("Error opening file"));
 	}
-	else std::cout<<"Error opening file"<<std::endl;
 	
 // Second part of the constructor: load the information of the maze.
 // Because we initially don't know what the size of the maze is, we first read the dimensions, then create a vector with the right dimension
@@ -45,7 +46,7 @@ Level::Level(std::string filename, int ratio){
 			i++;	
 		}
 		file_maze.close();
-	}else std::cout<<"Error opening file"<<std::endl;
+	}else throw(std::invalid_argument("Error opening file"));
 	
 	// Generate numbers in maze with ratio to available spaces of 1/10
 	generate_numbers(ratio);
@@ -64,4 +65,10 @@ void Level::generate_numbers(int ratio){
 		}
 		this->maze[pos] = rand()%9+1;
 	}
+	
+	// Check if level is playable:
+	if (this->maze[this->width+1])
+		throw(std::invalid_argument("Error, (1,1) in maze is not a free cell."));
+	
+	
 }

--- a/read.h
+++ b/read.h
@@ -6,6 +6,7 @@
 #include<iostream>
 #include<fstream>
 #include <ctime>
+#include <stdexcept>
 
 
 // declarations


### PR DESCRIPTION
tekstbestanden met de naam "lvl?.txt" waar het vraagteken de naam van het level is, worden nu automatisch weergegeven en kunnen geopend worden in het programma.
Daarnaast even opgezocht hoe je errors het beste kunt catchen, dat bleek met de library stdexcept te kunnen, dus dat is nu geimplementeerd.